### PR TITLE
chore: pin all workflow actions to full SHA1

### DIFF
--- a/.github/workflows/analyze-hook.yml
+++ b/.github/workflows/analyze-hook.yml
@@ -14,14 +14,14 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Comment on issue — started
         run: gh issue comment ${{ github.event.issue.number }} --body "Analyzing hook submission... this may take a few minutes. [Follow along](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@64c7a0ef71df67b14cb4471f4d9c8565c61042bf
         id: claude
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
         working-directory: site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: site/dist
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -15,16 +15,16 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         with:
           app-id: ${{ vars.REGISTRY_APP_ID }}
           private-key: ${{ secrets.REGISTRY_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
 

--- a/.github/workflows/review-hook.yml
+++ b/.github/workflows/review-hook.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
             echo "No hook files changed, skipping review."
           fi
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@64c7a0ef71df67b14cb4471f4d9c8565c61042bf
         if: steps.changed.outputs.hooks == 'true'
         id: claude
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
             echo "No hook files changed, skipping validation."
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         if: steps.changed.outputs.hooks == 'true'
         with:
           python-version: '3.12'


### PR DESCRIPTION
Replaces version tags with immutable commit SHAs for all GitHub Actions used in workflows.

**Actions pinned:**
- `actions/checkout`
- `actions/setup-python`
- `actions/setup-node`
- `actions/create-github-app-token`
- `actions/upload-pages-artifact`
- `actions/deploy-pages`
- `anthropics/claude-code-action`

**Why:** Pinning to full SHA1 ensures workflows always run the exact action code that was tested and avoids supply-chain risk from tags being moved or recreated.

Made with [Cursor](https://cursor.com)