### PR TITLE
fix: skip deleted files in zizmor audit

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,7 +28,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- '.github/workflows/' '.github/actions/')
+          FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- '.github/workflows/' '.github/actions/' | while read -r f; do [ -f "$f" ] && echo "$f"; done)
           if [ -n "$FILES" ]; then
             echo "$FILES" | xargs uvx zizmor --config .zizmor.yml
           else


### PR DESCRIPTION
## Summary
- Filters out deleted files before passing them to zizmor
- Fixes `invalid input` error when a PR deletes a workflow file (e.g., #323)

The `git diff --name-only` includes deleted files, but zizmor can't audit files that no longer exist on the branch.