### PR TITLE
fix(ci): harden Claude workflow tool permissions for public access

### DIFF
--- a/.github/workflows/analyze-hook.yml
+++ b/.github/workflows/analyze-hook.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: '--allowedTools "Bash(curl *),Bash(git *),Bash(gh *),Bash(python3 *),Read,Glob,Grep,Write"'
+          claude_args: '--allowedTools "Bash(curl *etherscan*),Bash(curl *blockscout*),Bash(curl *routescan*),Bash(git *),Bash(gh *),Bash(python3 *),Read,Glob,Grep,Write" --disallowedTools "Bash(env *),Bash(printenv *),Bash(set *),Bash(export *),Bash(cat /proc/*),Bash(cat /etc/*)"'
           prompt: |
             Analyze the hook submission in issue #${{ github.event.issue.number }}.
 

--- a/.github/workflows/review-hook.yml
+++ b/.github/workflows/review-hook.yml
@@ -42,7 +42,8 @@ jobs:
           show_full_output: true
           claude_args: >-
             --json-schema '{"type":"object","properties":{"review_body":{"type":"string"},"outcome":{"type":"string","enum":["APPROVE","REQUEST_CHANGES"]}},"required":["review_body","outcome"]}'
-            --allowedTools "Bash(curl *),Bash(python3 *),Read,Glob,Grep"
+            --allowedTools "Bash(curl *etherscan*),Bash(curl *blockscout*),Bash(curl *routescan*),Bash(python3 *),Read,Glob,Grep"
+            --disallowedTools "Bash(env *),Bash(printenv *),Bash(set *),Bash(export *),Bash(cat /proc/*),Bash(cat /etc/*)"
           prompt: |
             Review this PR by following the instructions in .claude/prompts/review-hook.md.
             Verify each hook file's flags, properties, and metadata against the on-chain source code.


### PR DESCRIPTION
## Summary
Hardens the Claude-powered workflows before opening issue-triggered analysis to public contributors.

### Changes
| Workflow | Change |
|----------|--------|
| `analyze-hook.yml` | Replaced unrestricted `Bash(curl *)` with domain-scoped curl (etherscan, blockscout, routescan only). Added `--disallowedTools` to block env variable reads and system file access. |
| `review-hook.yml` | Same curl restriction and disallowedTools. PR approval already posts as comment requiring human approval. |

### Why
When anyone can open an issue with the `submission` label, the issue body becomes attacker-controlled input to Claude. These changes prevent:
- **Secret exfiltration** — Claude can no longer `curl` to arbitrary URLs (e.g., sending `$ANTHROPIC_API_KEY` or `$ETHERSCAN_API_KEY` to an external server)
- **Environment variable leakage** — `env`, `printenv`, `set`, `export` are blocked
- **System file reads** — `/proc/*` and `/etc/*` are blocked

Etherscan/Blockscout/Routescan API calls still work as needed for hook analysis.

### Additional recommendation
Create a **dedicated Anthropic API key** for this repo with a spend cap, rather than sharing the org-wide key. This limits credit abuse to a set dollar amount.

## Test plan
- [ ] Trigger a hook submission and verify analysis completes (curl to Etherscan works)
- [ ] Verify Claude cannot curl to non-etherscan domains
- [ ] Verify PR review workflow still functions correctly