### PR TITLE
Add LayerMeme Base hooks

### DIFF
--- a/hooks/base/0x440f4148e323de5d8196582628971bfff802e8cc.json
+++ b/hooks/base/0x440f4148e323de5d8196582628971bfff802e8cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x440f4148e323de5d8196582628971bfff802e8cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Dynamic Fee Hook v2 (Base)",
+    "description": "A Uniswap v4 hook used by the LAYERMEME token launch platform that dynamically adjusts LP fees based on volatility, collects a protocol fee on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}

--- a/hooks/base/0x463005de948f7276cbc9522b704de12a09d168cc.json
+++ b/hooks/base/0x463005de948f7276cbc9522b704de12a09d168cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x463005de948f7276cbc9522b704de12a09d168cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Legacy Dynamic Fee Hook v2.1 (Base)",
+    "description": "A legacy Uniswap v4 dynamic-fee hook used by an early LAYERMEME token pool on Base. It adjusts LP fees based on volatility, collects protocol fees on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}

--- a/hooks/base/0x50948011f52dc3f2271c825a2ec60ad487cde8cc.json
+++ b/hooks/base/0x50948011f52dc3f2271c825a2ec60ad487cde8cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x50948011f52dc3f2271c825a2ec60ad487cde8cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Legacy Dynamic Fee Hook v2 (Base)",
+    "description": "A legacy Uniswap v4 dynamic-fee hook used by early LAYERMEME token pools on Base. It adjusts LP fees based on volatility, collects protocol fees on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}

--- a/hooks/base/0x5fef75737d2c547c9ea11e750b207239954368cc.json
+++ b/hooks/base/0x5fef75737d2c547c9ea11e750b207239954368cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x5fef75737d2c547c9ea11e750b207239954368cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Static Fee Hook v2 (Base)",
+    "description": "A Uniswap v4 hook used by the LAYERMEME token launch platform that enforces fixed LP fees for launched token pools, collects a protocol fee on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}

--- a/hooks/base/0xc8da6f806e9d89196f2d6e9301d6f936587328cc.json
+++ b/hooks/base/0xc8da6f806e9d89196f2d6e9301d6f936587328cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0xc8da6f806e9d89196f2d6e9301d6f936587328cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Legacy Static Fee Hook v2 (Base)",
+    "description": "A legacy Uniswap v4 static-fee hook used by early LAYERMEME token pools on Base. It enforces fixed LP fees, collects protocol fees on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
Adds LAYERMEME's Base Uniswap v4 hook registrations, including the current production hooks and legacy hooks that already have launched token pools.\n\nCurrent hooks:\n- Dynamic Fee Hook v2: 0x440f4148e323de5d8196582628971bfff802e8cc\n- Static Fee Hook v2: 0x5fef75737d2c547c9ea11e750b207239954368cc\n\nLegacy hooks with existing LAYERMEME pools:\n- Static Fee Hook v2: 0xc8da6f806e9d89196f2d6e9301d6f936587328cc\n- Dynamic Fee Hook v2: 0x50948011f52dc3f2271c825a2ec60ad487cde8cc\n- Dynamic Fee Hook v2.1: 0x463005de948f7276cbc9522b704de12a09d168cc\n\nValidation:\n- Flags were checked with scripts/compute_flags.py and match the deployed hook permission bits.\n- scripts/validate.py passes for all five added files.\n\nNote: scripts/aggregate.py currently fails locally on an unrelated existing Arbitrum hook description-length validation, so this PR intentionally includes only the new hook JSON files.\n\nRelated issue submissions: #535 and #536.