### PR TITLE
Add LayerMeme Base hook 0x5094

### DIFF
--- a/hooks/base/0x50948011f52dc3f2271c825a2ec60ad487cde8cc.json
+++ b/hooks/base/0x50948011f52dc3f2271c825a2ec60ad487cde8cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x50948011f52dc3f2271c825a2ec60ad487cde8cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Legacy Dynamic Fee Hook v2 (Base)",
+    "description": "A legacy Uniswap v4 dynamic-fee hook used by early LAYERMEME token pools on Base. It adjusts LP fees based on volatility, collects protocol fees on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
Adds the verified LayerMeme legacy dynamic fee hook on Base at 0x50948011f52dc3f2271c825a2ec60ad487cde8cc.\n\nThis supersedes the multi-hook submission in #537 so the PR follows the repository's one-hook-file-per-PR validation rule.\n\nValidation run locally:\n- /tmp/hooklist-venv/bin/python scripts/validate.py hooks/base/0x50948011f52dc3f2271c825a2ec60ad487cde8cc.json\n- /tmp/hooklist-venv/bin/python scripts/verify_flags.py hooks/base/0x50948011f52dc3f2271c825a2ec60ad487cde8cc.json