### PR TITLE
Add LayerMeme Base hook 0x5fef

### DIFF
--- a/hooks/base/0x5fef75737d2c547c9ea11e750b207239954368cc.json
+++ b/hooks/base/0x5fef75737d2c547c9ea11e750b207239954368cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x5fef75737d2c547c9ea11e750b207239954368cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Static Fee Hook v2 (Base)",
+    "description": "A Uniswap v4 hook used by the LAYERMEME token launch platform that enforces fixed LP fees for launched token pools, collects a protocol fee on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
Adds the verified LayerMeme static fee hook on Base at 0x5fef75737d2c547c9ea11e750b207239954368cc.\n\nThis supersedes the multi-hook submission in #537 so the PR follows the repository's one-hook-file-per-PR validation rule.\n\nValidation run locally:\n- /tmp/hooklist-venv/bin/python scripts/validate.py hooks/base/0x5fef75737d2c547c9ea11e750b207239954368cc.json\n- /tmp/hooklist-venv/bin/python scripts/verify_flags.py hooks/base/0x5fef75737d2c547c9ea11e750b207239954368cc.json