### PR TITLE
Add LayerMeme Base hook 0xc8da

### DIFF
--- a/hooks/base/0xc8da6f806e9d89196f2d6e9301d6f936587328cc.json
+++ b/hooks/base/0xc8da6f806e9d89196f2d6e9301d6f936587328cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0xc8da6f806e9d89196f2d6e9301d6f936587328cc",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Legacy Static Fee Hook v2 (Base)",
+    "description": "A legacy Uniswap v4 static-fee hook used by early LAYERMEME token pools on Base. It enforces fixed LP fees, collects protocol fees on launched token swaps, and supports optional MEV protection modules and pool extensions.",
+    "deployer": "0x5f05daf1312d62da92497edc6f3e39e265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
Adds the verified LayerMeme legacy static fee hook on Base at 0xc8da6f806e9d89196f2d6e9301d6f936587328cc.\n\nThis supersedes the multi-hook submission in #537 so the PR follows the repository's one-hook-file-per-PR validation rule.\n\nValidation run locally:\n- /tmp/hooklist-venv/bin/python scripts/validate.py hooks/base/0xc8da6f806e9d89196f2d6e9301d6f936587328cc.json\n- /tmp/hooklist-venv/bin/python scripts/verify_flags.py hooks/base/0xc8da6f806e9d89196f2d6e9301d6f936587328cc.json