### PR TITLE
Add LayerMeme Base hook 0x2afe

### DIFF
--- a/hooks/base/0x2afeacbe0907fba9f86ed3a38b3643bdb9ffa8cc.json
+++ b/hooks/base/0x2afeacbe0907fba9f86ed3a38b3643bdb9ffa8cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x2aFEaCbe0907fba9F86Ed3A38b3643Bdb9Ffa8CC",
+    "chain": "base",
+    "chainId": 8453,
+    "name": "LayerMeme Static Fee Hook v2 (Base)",
+    "description": "A Uniswap v4 hook used by the LAYERMEME token launch platform that enforces fixed LP fees for launched token pools, collects a protocol fee on launched token swaps, and supports optional MEV protection modules and pool extensions without requiring custom swap data.",
+    "deployer": "0x5f05Daf1312d62Da92497edC6F3e39E265999103",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": false,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
Adds the verified LayerMeme Static Fee Hook v2 deployment on Base. This is a one-hook PR with flags validated against the address bitmask and schema validation passing locally.\n\nValidation:\n- python scripts/validate.py hooks/base/0x2afeacbe0907fba9f86ed3a38b3643bdb9ffa8cc.json\n- python scripts/verify_flags.py hooks/base/0x2afeacbe0907fba9f86ed3a38b3643bdb9ffa8cc.json