### PR TITLE
fix: trim The Pool hook description to fit 500-char schema limit

### DIFF
--- a/hooks/arbitrum/0x486579de6391053df88a073cebd673dd545200cc.json
+++ b/hooks/arbitrum/0x486579de6391053df88a073cebd673dd545200cc.json
@@ -4,7 +4,7 @@
     "chain": "arbitrum",
     "chainId": 42161,
     "name": "The Pool",
-    "description": "The Pool protocol's volatility-adjusted fee hook (on-chain contract: DynamicFeeHookV2). Takes a percentage of each swap's output via afterSwapReturnsDelta (25 bps base, scaling up to 37.5 bps under realized volatility) and routes it to a fee distributor. Also supports reserve-sale fills in beforeSwap, where a registered vault can offer single-sided inventory to swappers at a chosen price in either price-improvement or vault-spread mode. Second hook deployment from The Pool project (github.com/emilianosolazzi/The-Pool); see also the sibling hook at 0x62076c1cb0ea57acd2353ff45226a1fb1e6100c4.",
+    "description": "The Pool protocol's volatility-adjusted fee hook (on-chain contract: DynamicFeeHookV2). Takes a percentage of each swap's output via afterSwapReturnsDelta (25 bps base, scaling up to 37.5 bps under realized volatility) and routes it to a fee distributor. Also supports reserve-sale fills in beforeSwap, where a registered vault can offer single-sided inventory to swappers at a chosen price in either price-improvement or vault-spread mode.",
     "deployer": "0xe5f5Ef79b3DFF47EcDf7842645222e43AD0ed080",
     "verifiedSource": true,
     "auditUrl": ""


### PR DESCRIPTION
## Summary

`main` is currently failing the `regenerate.yml` workflow because `aggregate.py` re-validates every hook against the schema and `hooks/arbitrum/0x486579de6391053df88a073cebd673dd545200cc.json`'s description is **622 chars**, over the schema's `maxLength: 500`.

The over-length description was introduced by commit \`42d55f4\` ("refine: clarify The Pool protocol brand and contract identity"). \`validate.yml\` passed on that PR — it only runs against the PR's changed files — but the validator on aggregation in \`regenerate.yml\` re-checks the whole tree against the same schema and now blocks main.

## Change

Trimmed the description from 622 → 440 chars by dropping the trailing meta-narrative:
- Removed: "Second hook deployment from The Pool project (github.com/emilianosolazzi/The-Pool); see also the sibling hook at 0x62076c1cb0ea57acd2353ff45226a1fb1e6100c4."
- Kept verbatim: the actual hook behavior — DynamicFeeHookV2 contract reference, the afterSwapReturnsDelta fee mechanism (25 bps base / 37.5 bps cap), and the reserve-sale fill mode in beforeSwap.

Sibling-hook cross-references and project repo URLs are not part of the hook-data spec; if surfacing those is desired, it should be a schema change, not a 500-char overrun.

## Verification

\`\`\`
$ python scripts/validate.py hooks/arbitrum/0x486579de6391053df88a073cebd673dd545200cc.json
  OK
$ python scripts/aggregate.py
Aggregated 199 hooks into hooklist.json
Filtered 15 vanilla-swap hooks into hooklist-vanilla-swap.json
\`\`\`

## Suggested follow-up (separate PR)

The PR-time \`validate.py\` walks only changed files (\`gh pr diff\`-style); the merge-time \`aggregate.py\` revalidates the whole repo. Consider always running \`aggregate.py\` (or at least its full-repo schema sweep) in \`validate.yml\` so this class of breakage is caught at PR time, not on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)