### PR TITLE
fix(analyze-hook): warn when submitter name/description is absent

### DIFF
--- a/.claude/prompts/classify-hook.md
+++ b/.claude/prompts/classify-hook.md
@@ -100,9 +100,13 @@ Process:
 Return a `warnings` array of short strings (≤20 entries) covering any inconsistency a human reviewer should see:
 
 - **Rejected submitter name** — format: `Submitter-proposed name "<X>" rejected: <reason>. Using "<Y>".`
+- **Absent submitter name** — when the submission has no name (empty, missing, or `_No response_`), format: `Submitter did not provide a name. Using AI-derived "<Y>".`
 - **Rejected submitter description** — format: `Submitter-proposed description rejected: <reason>. Using AI-generated description.`
+- **Absent submitter description** — when the submission has no description (empty, missing, or `_No response_`), format: `Submitter did not provide a description. Using AI-generated description.`
 - **Flag mismatch** — if the hook extends `BaseHook` and `getHookPermissions()` does not match `computed_flags.json`, add: `getHookPermissions() returns <X> but address bitmask encodes <Y>.`
 - **Other source-vs-submission inconsistencies** — e.g. submitter claimed `deployer` but the source-deploying address is different (only if you can verify this from source).
+
+Both name and description are required cases — always emit a warning whenever the AI's text (rather than the submitter's) lands in the registry, whether because the submitter's suggestion was rejected or because no suggestion was provided. This way reviewers can tell at a glance which fields are human-supplied-and-verified vs AI-authored.
 
 If everything is clean, return `warnings: []`.
 


### PR DESCRIPTION
## Summary

Today's PR-triage audit on six bot-authored hook PRs surfaced that **PR #570 (TTTHook)** landed in the registry with zero warnings even though both the submitter-provided Hook Name and Description were `_No response_` — meaning 100% of the user-facing identity was AI-authored, with no audit trail saying so.

The prompt at `.claude/prompts/classify-hook.md` already says (§6 step 4, §7 step 3) that warnings should fire on **rejected OR absent** submitter fields. But §8 only enumerates the *rejected*-case templates. The AI followed §8's literal forms and silently dropped warnings for the absent case.

## What this changes

`.claude/prompts/classify-hook.md` §8 now has two more templates:

- **Absent submitter name** — `Submitter did not provide a name. Using AI-derived "<Y>".`
- **Absent submitter description** — `Submitter did not provide a description. Using AI-generated description.`

Plus a closing paragraph making explicit that warnings fire on **rejection or absence** — the threat model is "AI-authored text landed in the registry; the reviewer needs to see it." Absence and rejection get the same treatment.

## What this does NOT change

- `assemble_hook.py` — no code changes. Warnings already flow opaquely through `generate_pr_body()` as bullets.
- Existing assembler tests — all 22 still pass.
- `analyze-hook.yml`'s JSON schema for `warnings` (max 20 entries, 300 chars each) — new templates are ~80 chars.

## Test plan

- [ ] On the next public hook submission with empty Hook Name / Description fields, the analyze-hook PR body's Warnings section should contain the new `Submitter did not provide…` bullets.
- [ ] On a submission with both fields populated, the Warnings section should be unchanged from today's behavior (None, or only rejection-style bullets if the AI rejected something).
- [ ] On a future submission that pairs a present name with an absent description (or vice versa), exactly one of the new bullets should appear.

## Audit context

The four PRs from today's batch that *did* emit warnings (#572 length, #576 platform-scope, #577 audit claim) continue to work the same — they're all "rejected"-case templates and unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)