### PR TITLE
ci: skip removed files in validate and review-hook workflows

### DIFF
--- a/.github/workflows/review-hook.yml
+++ b/.github/workflows/review-hook.yml
@@ -32,7 +32,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          HOOK_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename' | grep '^hooks/' || true)
+          # Filter out removed files — review verifies hook content against on-chain
+          # source, which only makes sense for files still present on the PR head.
+          HOOK_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[] | select(.status != "removed") | .filename' | grep '^hooks/' || true)
           if [ -n "$HOOK_FILES" ]; then
             echo "hooks=true" >> "$GITHUB_OUTPUT"
             # Save changed file list for Claude's prompt
@@ -71,7 +73,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          HOOK_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename' | grep '^hooks/')
+          HOOK_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[] | select(.status != "removed") | .filename' | grep '^hooks/')
           for HOOK_FILE in $HOOK_FILES; do
             CHAIN=$(echo "$HOOK_FILE" | cut -d/ -f2)
             ADDRESS=$(basename "$HOOK_FILE" .json)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,17 +31,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          CHANGED=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
-          HOOK_FILES=$(echo "$CHANGED" | grep '^hooks/' || true)
-          if [ -z "$HOOK_FILES" ]; then
+          FILES_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files")
+          CHANGED=$(echo "$FILES_JSON" | jq -r '.[].filename')
+          HAS_HOOK_CHANGES=$(echo "$CHANGED" | grep '^hooks/' || true)
+          if [ -z "$HAS_HOOK_CHANGES" ]; then
             echo "hooks=false" >> "$GITHUB_OUTPUT"
             echo "No hook files changed, skipping validation."
             exit 0
           fi
-          echo "hooks=true" >> "$GITHUB_OUTPUT"
-          echo "$HOOK_FILES" | sed 's|^|pr/|' > changed_hooks.txt
 
-          # Exact-diff policy: only hooks/** allowed, exactly one file
+          # Exact-diff policy: only hooks/** allowed, exactly one file (applies to add/modify/remove)
           INVALID=$(echo "$CHANGED" | grep -v '^hooks/' || true)
           if [ -n "$INVALID" ]; then
             echo "::error::PR modifies files outside hooks/: $INVALID"
@@ -52,6 +51,17 @@ jobs:
             echo "::error::PR must change exactly one hook file, found $COUNT changed files"
             exit 1
           fi
+
+          # Schema validation only applies to files still present on the PR head
+          # (added/modified). Removed files have no content to validate.
+          HOOK_FILES=$(echo "$FILES_JSON" | jq -r '.[] | select(.status != "removed") | .filename' | grep '^hooks/' || true)
+          if [ -z "$HOOK_FILES" ]; then
+            echo "hooks=false" >> "$GITHUB_OUTPUT"
+            echo "Hook file is being removed, nothing to schema-validate."
+            exit 0
+          fi
+          echo "hooks=true" >> "$GITHUB_OUTPUT"
+          echo "$HOOK_FILES" | sed 's|^|pr/|' > changed_hooks.txt
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         if: steps.changed.outputs.hooks == 'true'


### PR DESCRIPTION
## Summary

Both `validate.yml` and `review-hook.yml` query the GitHub PR files API without filtering by `status`. Removal-shaped PRs (e.g., reverting a hook entry) crash because:

- `validate.py` receives a path that no longer exists on the PR head and fails with `FileNotFoundError`.
- `review-hook` would ask Claude to verify a file against on-chain source even though the file is gone from the PR tree.

Surfaced while reverting #580 (the `0x0f7f…` ShitGiftHook entry the submitter asked to drop after merge) — see PR #585, whose `validate` check is currently red purely from this bug.

## Fix

- Filter the API response with `select(.status != "removed")` in both workflows.
- In `validate.yml`, reshuffle so the *exact-diff policy* (only `hooks/**`, exactly one file) still runs on the full changed-files list **before** the early-exit on "nothing to schema-validate." A naive filter-then-early-exit would let a PR remove a hook + modify a non-hook file and bypass policy.

## Behavior matrix

| PR shape | Before | After |
|---|---|---|
| Hook add/modify (1 hooks/ file) | validate runs, review runs | unchanged |
| Pure hook removal (1 hooks/ file) | validate crashes | policy enforced, nothing to validate, SUCCESS |
| Removal + non-hook file | crashed before policy check | policy fires, FAIL with error message |
| Non-hook PR (workflows, docs) | both early-exit SUCCESS | unchanged |

## Test plan

- [x] `validate` check passes on this PR (no hooks/ touched → early-exit SUCCESS)
- [x] `review` check passes on this PR (no hooks/ touched → claude-action skipped, job SUCCESS)
- [ ] After merge, push empty commit to #585 and confirm `validate` + `review` early-exit SUCCESS for that removal PR