### PR TITLE
Add WC2026Hook hook on xlayer

### DIFF
--- a/hooks/xlayer/0x28F389d3D730C72141dE6bb7516FEf6F487F80cc.json
+++ b/hooks/xlayer/0x28F389d3D730C72141dE6bb7516FEf6F487F80cc.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x28F389d3D730C72141dE6bb7516FEf6F487F80cc",
+    "chain": "xlayer",
+    "chainId": 196,
+    "name": "WC2026Hook",
+    "description": "A Uniswap v4 campaign hook that observes official-pool swaps, collects configurable native OKB GoalPool fees, attributes weighted volume to a user and country from hookData, creates shot credits, and resolves Goal or Super Goal rewards through an external randomness resolver.",
+    "deployer": "",
+    "verifiedSource": true,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": false,
+    "afterInitialize": false,
+    "beforeAddLiquidity": false,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": false,
+    "upgradeable": false,
+    "requiresCustomSwapData": true,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
## Summary
Adds the verified `WC2026Hook` deployment on X Layer mainnet to the hook registry.

## Hook
- Chain: `xlayer`
- Chain ID: `196`
- Address: `0x28F389d3D730C72141dE6bb7516FEf6F487F80cc`
- Pool: `WC2026/native OKB`
- PoolId: `0x438a57939316376890c7b2d49bd38241489261db1dc676cb4b4f8c16dcc41eb2`

## Flags
Computed from the hook address bitmask:
- `beforeSwap`: `true`
- `afterSwap`: `true`
- `beforeSwapReturnsDelta`: `true`
- `afterSwapReturnsDelta`: `true`
- all other hook flags: `false`

## Properties
- `dynamicFee`: `false`
- `upgradeable`: `false`
- `requiresCustomSwapData`: `true`
- `vanillaSwap`: `false`
- `swapAccess`: `none`

## Validation
- `python3 scripts/verify_flags.py hooks/xlayer/0x28F389d3D730C72141dE6bb7516FEf6F487F80cc.json`
- `/tmp/hooklist-validate-venv/bin/python scripts/validate.py hooks/xlayer/0x28F389d3D730C72141dE6bb7516FEf6F487F80cc.json`