### PR TITLE
Add Ring FewV2 Aggregator Hook on ethereum

### DIFF
--- a/hooks/ethereum/0x3dd864a80cc5dc3d6e3f4e1a6af92b0d2047e888.json
+++ b/hooks/ethereum/0x3dd864a80cc5dc3d6e3f4e1a6af92b0d2047e888.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x3dd864a80cc5dc3d6e3f4e1a6af92b0d2047e888",
+    "chain": "ethereum",
+    "chainId": 1,
+    "name": "Ring FewV2 Aggregator Hook",
+    "description": "Ownerless router-compatible Uniswap v4 hook that exposes Ring FewV2 AMM liquidity through v4 swaps. The hook uses empty hookData, registers aggregator pools, exposes quote and pseudoTotalValueLocked for routing discovery, and has no hook owner, pause, upgrade path, or route-control admin.",
+    "deployer": "0x61e75d5c5dee4205a5bbcd9fbc40498b693197ad",
+    "verifiedSource": true,
+    "auditUrl": "https://github.com/RingProtocol/ring-v4-aggregator-hook-audit/blob/audit-router-compat-aggregator-interface/docs/ABDK_Ring_Aggregator_Hook_Audit_Report_v1.1.pdf"
+  },
+  "flags": {
+    "beforeInitialize": true,
+    "afterInitialize": false,
+    "beforeAddLiquidity": true,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": false,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": true,
+    "afterSwapReturnsDelta": false,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": false,
+    "upgradeable": false,
+    "requiresCustomSwapData": false,
+    "vanillaSwap": false,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the updated router-compatible Ring FewV2 Aggregator Hook deployment on Ethereum.

This supersedes the earlier Ring hook entry for routing-integration purposes. The new hook keeps the direct FewV2 swap path, uses empty hookData, and adds the UniRoute-facing aggregator compatibility surface for routing discovery.

## Hook

| Field | Value |
| --- | --- |
| Chain | Ethereum |
| Hook | `0x3Dd864a80cc5Dc3d6e3F4E1A6aF92B0D2047e888` |
| Source | https://github.com/RingProtocol/ring-v4-aggregator-hook-audit/tree/audit-router-compat-aggregator-interface |
| Audit | https://github.com/RingProtocol/ring-v4-aggregator-hook-audit/blob/audit-router-compat-aggregator-interface/docs/ABDK_Ring_Aggregator_Hook_Audit_Report_v1.1.pdf |

## Flags

| Flag | Value |
| --- | --- |
| beforeInitialize | true |
| afterInitialize | false |
| beforeAddLiquidity | true |
| afterAddLiquidity | false |
| beforeRemoveLiquidity | false |
| afterRemoveLiquidity | false |
| beforeSwap | true |
| afterSwap | false |
| beforeDonate | false |
| afterDonate | false |
| beforeSwapReturnsDelta | true |
| afterSwapReturnsDelta | false |
| afterAddLiquidityReturnsDelta | false |
| afterRemoveLiquidityReturnsDelta | false |

## Properties

| Property | Value |
| --- | --- |
| dynamicFee | false |
| upgradeable | false |
| requiresCustomSwapData | false |
| vanillaSwap | false |
| swapAccess | none |

## Validation

- Added one hook JSON file under `hooks/ethereum/`.
- Validated the new file against `schema.json`.
- Checked `getHookPermissions()` on the deployed hook and matched the JSON flags.
