### PR TITLE
Remove unused OKX auth; always fetch X Layer source unauthenticated

### DIFF
--- a/.github/workflows/analyze-hook.yml
+++ b/.github/workflows/analyze-hook.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Fetch source
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          OKX_ACCESS_KEY: ${{ secrets.OKX_ACCESS_KEY }}
-          OKX_SECRET_KEY: ${{ secrets.OKX_SECRET_KEY }}
-          OKX_PASSPHRASE: ${{ secrets.OKX_PASSPHRASE }}
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           CHAIN: ${{ steps.prefilter.outputs.CHAIN }}

--- a/.github/workflows/review-hook.yml
+++ b/.github/workflows/review-hook.yml
@@ -70,9 +70,6 @@ jobs:
         if: steps.changed.outputs.hooks == 'true'
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          OKX_ACCESS_KEY: ${{ secrets.OKX_ACCESS_KEY }}
-          OKX_SECRET_KEY: ${{ secrets.OKX_SECRET_KEY }}
-          OKX_PASSPHRASE: ${{ secrets.OKX_PASSPHRASE }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |

--- a/scripts/fetch_source.py
+++ b/scripts/fetch_source.py
@@ -34,34 +34,6 @@ def fetch_and_parse(response_path: str, outdir: str = ".sources", explorer_type:
     return parse_etherscan(response_path, outdir)
 
 
-def okx_curl_args(url: str, request_path: str) -> list[str]:
-    """Build OKX-authenticated curl arguments for the verified contract API."""
-    import base64
-    import datetime
-    import hashlib
-    import hmac
-
-    access_key = os.environ.get("OKX_ACCESS_KEY", "")
-    secret_key = os.environ.get("OKX_SECRET_KEY", "")
-    passphrase = os.environ.get("OKX_PASSPHRASE", "")
-    if not (access_key and secret_key and passphrase):
-        raise RuntimeError("OKX_ACCESS_KEY, OKX_SECRET_KEY, and OKX_PASSPHRASE are required for X Layer source fetches.")
-
-    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
-    prehash = f"{timestamp}GET{request_path}"
-    signature = base64.b64encode(
-        hmac.new(secret_key.encode(), prehash.encode(), hashlib.sha256).digest()
-    ).decode()
-
-    return [
-        "-H", f"OK-ACCESS-KEY: {access_key}",
-        "-H", f"OK-ACCESS-SIGN: {signature}",
-        "-H", f"OK-ACCESS-PASSPHRASE: {passphrase}",
-        "-H", f"OK-ACCESS-TIMESTAMP: {timestamp}",
-        url,
-    ]
-
-
 def main():
     if len(sys.argv) < 3:
         print(f"Usage: {sys.argv[0]} <chain> <address> [--api-key <key>] [--output <path>] [--outdir <dir>]", file=sys.stderr)
@@ -103,7 +75,6 @@ def main():
         parser = parse_etherscan
     elif explorer_type == "okx":
         url = f"{explorer_url}&contractAddress={address}"
-        request_path = url.removeprefix("https://web3.okx.com")
         parser = parse_okx
     else:
         # Blockscout / Routescan — no API key
@@ -111,14 +82,8 @@ def main():
         parser = parse_etherscan
 
     # Fetch
-    try:
-        curl_args = okx_curl_args(url, request_path) if explorer_type == "okx" else [url]
-    except RuntimeError as e:
-        print(str(e), file=sys.stderr)
-        sys.exit(1)
-
     result = subprocess.run(
-        ["curl", "-s", "-o", response_file, "-w", "%{http_code}", *curl_args],
+        ["curl", "-s", "-o", response_file, "-w", "%{http_code}", url],
         capture_output=True, text=True
     )
     if result.returncode != 0:
@@ -150,14 +115,12 @@ def main():
             impl_url = f"{explorer_url}&module=contract&action=getsourcecode&address={impl_address}&apikey={api_key}"
         elif explorer_type == "okx":
             impl_url = f"{explorer_url}&contractAddress={impl_address}"
-            request_path = impl_url.removeprefix("https://web3.okx.com")
         else:
             impl_url = f"{explorer_url}?module=contract&action=getsourcecode&address={impl_address}"
 
         impl_response_file = "explorer_impl_response.json"
-        impl_curl_args = okx_curl_args(impl_url, request_path) if explorer_type == "okx" else [impl_url]
         impl_result = subprocess.run(
-            ["curl", "-s", "-o", impl_response_file, "-w", "%{http_code}", *impl_curl_args],
+            ["curl", "-s", "-o", impl_response_file, "-w", "%{http_code}", impl_url],
             capture_output=True, text=True
         )
         if explorer_type == "sourcify" and impl_result.stdout.strip() == "404":


### PR DESCRIPTION
## Problem

X Layer (OKX) hook submissions were failing source verification in CI (e.g. [run 28876960754](https://github.com/Uniswap/hooklist/actions/runs/28876960754/job/85654550103), issue #709). The `Fetch source` step aborted with:

> OKX_ACCESS_KEY, OKX_SECRET_KEY, and OKX_PASSPHRASE are required for X Layer source fetches.

The `OKX_*` repo secrets are unset, so `fetch_source.py` raised before ever contacting OKX and the hook got labeled `unverified`.

## Root cause

The OKX `verify-contract-info` endpoint is **public** — it returns verified source with no `OK-ACCESS-*` signature headers. You can hit it directly in a browser:

```
https://web3.okx.com/api/v5/xlayer/contract/verify-contract-info?chainShortName=xlayer&contractAddress=0x2e11d4f7bbb9af02a439fa5bedb8a4c7ce9540c0
```

Our code assumed OKX's signed-request scheme (correct for trading/account APIs) was needed here. It wasn't — and the required secrets were never populated anyway, making the automated path impossible to satisfy.

## Fix

- Delete the `okx_curl_args` signing helper and always do a plain unauthenticated `curl`, matching browser behavior — for both the primary and proxy-implementation fetches.
- Remove the now-unused `OKX_ACCESS_KEY` / `OKX_SECRET_KEY` / `OKX_PASSPHRASE` env vars from the `analyze-hook` and `review-hook` workflows.

## Verification

Ran the updated script against the live endpoint:

```
$ python3 scripts/fetch_source.py xlayer 0x2e11d4f7bbb9af02a439fa5bedb8a4c7ce9540c0
ContractName: KickItHook
Verified: True
Source fetched and parsed: KickItHook (verified=True, proxy=False)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)