### PR TITLE
Add GoldenGoalHook on xlayer

### DIFF
--- a/hooks/xlayer/0x742d6c5ec8eca72096c24a1287f5ef0efd0c50c4.json
+++ b/hooks/xlayer/0x742d6c5ec8eca72096c24a1287f5ef0efd0c50c4.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x742d6c5ec8eca72096c24a1287f5ef0efd0c50c4",
+    "chain": "xlayer",
+    "chainId": 196,
+    "name": "GoldenGoalHook",
+    "description": "World Cup-style arena hook for GOAL/WOKB: match-phase dynamic fees (Kickoff/Live/ExtraTime/FinalWhistle), on-chain goal points per swap, 20 bps skim split 50/50 pot/buyback with GOAL auto-burn, anti-snipe max-buy window, and pro-rata pot claims after Final Whistle.",
+    "deployer": "0x9a8a00698043f52012d9e4cd9c0badf5b509d2fb",
+    "verifiedSource": false,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": false,
+    "afterInitialize": true,
+    "beforeAddLiquidity": false,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": false,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": false,
+    "vanillaSwap": true,
+    "swapAccess": "temporal"
+  }
+}


### PR DESCRIPTION
## Summary

Adds **GoldenGoalHook** on X Layer (chain 196) to the public Uniswap v4 hook registry.

- **Address:** `0x742d6c5ec8eca72096c24a1287f5ef0efd0c50c4`
- **Chain:** xlayer / 196
- **Deployer:** `0x9a8a00698043f52012d9e4cd9c0badf5b509d2fb`

### Mechanisms
- Match-phase **dynamic fees** (Kickoff / Live / ExtraTime / FinalWhistle)
- On-chain **goal points** per swap (scoreboard)
- **20 bps skim** split 50% prize pot / 50% buyback (GOAL auto-burn)
- **Anti-snipe** max-buy window after initialize (`swapAccess: temporal`)
- **Pro-rata pot claims** after Final Whistle

### Flags (from address bitmask)
- `afterInitialize`, `beforeSwap`, `afterSwap`, `afterSwapReturnsDelta`

### Properties
- `dynamicFee: true`
- `upgradeable: false`
- `requiresCustomSwapData: false`
- `vanillaSwap: true`
- `swapAccess: temporal`

### Related
- Token (GOAL): `0x984046E1b1f50817F52eB1AeFC8556bc3473d433`
- PoolId: `0x0b7ef12de1ab0d1a105f08532899d23022da15537f7758d9a128681065d31c66`
- Project: Build X World Cup × Uniswap v4 on X Layer

## Validation
- `scripts/validate.py` ✅
- `scripts/verify_flags.py` ✅

## Note
`verifiedSource` is currently `false` (source not yet verified on OKLink). Happy to flip to `true` after verification if maintainers prefer that order.