### PR TITLE
Add Mundial hook on X Layer

### DIFF
--- a/hooks/xlayer/0x51f3d18a574c1deec5c04d395573cda9248dd0c4.json
+++ b/hooks/xlayer/0x51f3d18a574c1deec5c04d395573cda9248dd0c4.json
@@ -6,7 +6,7 @@
     "name": "Mundial",
     "description": "A Uniswap v4 hook that runs an autonomous eight-team knockout World Cup inside one dynamic-fee OKB/MUNDIAL pool. Traders pledge a team once; during that team's match their swaps count as shots and volume converts to goals, with golden goals settled inside the scoring swap. Results derive only from swaps and timestamps — no owner, oracle, or randomness. Fans get tiered fee discounts; a 0.20% skim builds a Champions Pot claimed pro-rata by champion fans, leftovers donated to LPs.",
     "deployer": "0x80bc3f17da930c473205eec282850fb8c46436b0",
-    "verifiedSource": false,
+    "verifiedSource": true,
     "auditUrl": ""
   },
   "flags": {

--- a/hooks/xlayer/0x51f3d18a574c1deec5c04d395573cda9248dd0c4.json
+++ b/hooks/xlayer/0x51f3d18a574c1deec5c04d395573cda9248dd0c4.json
@@ -1,0 +1,35 @@
+{
+  "hook": {
+    "address": "0x51f3d18a574c1deec5c04d395573cda9248dd0c4",
+    "chain": "xlayer",
+    "chainId": 196,
+    "name": "Mundial",
+    "description": "A Uniswap v4 hook that runs an autonomous eight-team knockout World Cup inside one dynamic-fee OKB/MUNDIAL pool. Traders pledge a team once; during that team's match their swaps count as shots and volume converts to goals, with golden goals settled inside the scoring swap. Results derive only from swaps and timestamps — no owner, oracle, or randomness. Fans get tiered fee discounts; a 0.20% skim builds a Champions Pot claimed pro-rata by champion fans, leftovers donated to LPs.",
+    "deployer": "0x80bc3f17da930c473205eec282850fb8c46436b0",
+    "verifiedSource": false,
+    "auditUrl": ""
+  },
+  "flags": {
+    "beforeInitialize": false,
+    "afterInitialize": true,
+    "beforeAddLiquidity": false,
+    "afterAddLiquidity": false,
+    "beforeRemoveLiquidity": false,
+    "afterRemoveLiquidity": false,
+    "beforeSwap": true,
+    "afterSwap": true,
+    "beforeDonate": false,
+    "afterDonate": false,
+    "beforeSwapReturnsDelta": false,
+    "afterSwapReturnsDelta": true,
+    "afterAddLiquidityReturnsDelta": false,
+    "afterRemoveLiquidityReturnsDelta": false
+  },
+  "properties": {
+    "dynamicFee": true,
+    "upgradeable": false,
+    "requiresCustomSwapData": false,
+    "vanillaSwap": true,
+    "swapAccess": "none"
+  }
+}


### PR DESCRIPTION
Adds **Mundial** — a Uniswap v4 hook on X Layer mainnet (chainId 196) that runs an autonomous eight-team knockout World Cup inside one dynamic-fee OKB/MUNDIAL pool.

- **Hook**: `0x51f3d18a574c1DeEC5c04d395573cda9248Dd0C4` (CREATE2-mined; flags decoded from address bitmask `0x10c4`: afterInitialize, beforeSwap, afterSwap, afterSwapReturnsDelta)
- **Explorer**: https://www.oklink.com/x-layer/address/0x51f3d18a574c1DeEC5c04d395573cda9248Dd0C4
- **Source**: https://github.com/Tonyflam/2_okx (77 passing tests incl. fuzz; explorer source verification currently pending — `verifiedSource` set to `false` honestly)
- No owner, oracle, randomness, or upgradeability; vanilla swaps work without hookData.

Built for the OKX × X Layer "Hook × World Cup" hackathon.